### PR TITLE
Changed self.splice arguments such that it now empties the array

### DIFF
--- a/gn-map.html
+++ b/gn-map.html
@@ -147,8 +147,8 @@ children like polygons, points and markers.
     attached: function () {
       var self = this;
       this.addEventListener('update-gn-map', function () {
-          self.splice('polygons', -1, 0);
-          self.splice('markers', -1, 0);
+          self.splice('polygons', -1);
+          self.splice('markers', -1);
 
           self.queryAllEffectiveChildren('gn-poly').forEach(function (polygon) {
             self.push('polygons', polygon.asObject());


### PR DESCRIPTION
Before it was not clearing up the array (`polygons`/`markers`) which led to multiple polygon/marker objects with same attributes in the array.